### PR TITLE
[hopsworks-794] flyway schema history should be replaced only if the …

### DIFF
--- a/test_manifesto
+++ b/test_manifesto
@@ -1,2 +1,1 @@
-logicalclocks/hopsworks/master
-logicalclocks/hopsworks-chef/master
+siroibaf/hopsworks-chef/HOPSWORKS-794


### PR DESCRIPTION
…last migration was 0.5.0