### PR TITLE
[HOPSWORKS-868] Remove usages of case node['platform'] to allow RHEL …

### DIFF
--- a/test_manifesto
+++ b/test_manifesto
@@ -1,2 +1,4 @@
-logicalclocks/hopsworks/master
-logicalclocks/hopsworks-chef/master
+siroibaf/hopsmonitor-chef/HOPSWORKS-868
+siroibaf/hive-chef/HOPSWORKS-868
+siroibaf/epipe-chef/HOPSWORKS-868
+siroibaf/hops-hadoop-chef/HOPSWORKS-868


### PR DESCRIPTION
…installation