### PR TITLE
[HOPSWORKS-852] (Append)

### DIFF
--- a/test_manifesto
+++ b/test_manifesto
@@ -1,2 +1,1 @@
-logicalclocks/hopsworks/master
-logicalclocks/hopsworks-chef/master
+Limmen/tensorflow-chef/HOPSWORKS-852


### PR DESCRIPTION
- Install petastorm from pypi to be compatible with airgapped installations