### PR TITLE
[HOPSWORKS-1042] Python kernels with capital letters are filtered out…

### DIFF
--- a/test_manifesto
+++ b/test_manifesto
@@ -1,2 +1,1 @@
-logicalclocks/hopsworks/master
-logicalclocks/hopsworks-chef/master
+siroibaf/hopsworks/HOPSWORKS-1042


### PR DESCRIPTION
… by Jupyter Notebook