### PR TITLE
HOPSWORKS-1229 - conda update to 4.7

### DIFF
--- a/scripts/generate_test_manifesto.sh
+++ b/scripts/generate_test_manifesto.sh
@@ -51,6 +51,13 @@ fi
 
 grep "branch: \"$1\"" Berksfile > /dev/null
 
+if [ $? -ne 0 ] ; then
+    echo ""
+    echo "Error."
+    echo "Could not find the branch $1 in hopsworks-chef/Berksfile"
+    echo ""    
+    exit 2
+fi
 
 cp -f Berksfile Berksfile.$1
 
@@ -72,12 +79,12 @@ repo=$(git remote -v | grep origin | grep fetch | sed -e 's/origin\tgit@github.c
 
 if [ $NO_HOPSWORKS -eq 0 ] ; then
     echo "${repo}/hopsworks/$1" > test_manifesto
-    echo "hopshadoop/hopsworks-chef/$1" >> test_manifesto
+    echo "logicalclocks/hopsworks-chef/$1" >> test_manifesto
 else
-    echo "hopshadoop/hopsworks-chef/$1" > test_manifesto    
+    echo "logicalclocks/hopsworks-chef/$1" > test_manifesto    
 fi    
 
-grep $1 ../hopsworks-chef/Berksfile.${1} | sed -e 's/.*hopshadoop/hopshadoop/' | sed -e 's/",\s* branch:\s*"/\//' | sed -e 's/"//' >> test_manifesto
+grep $1 ../hopsworks-chef/Berksfile.${1} | sed -e 's/.*logicalclocks/logicalclocks/' | sed -e 's/",\s* branch:\s*"/\//' | sed -e 's/"//' >> test_manifesto
 
 git commit -am 'updated test_manifesto'
 git push

--- a/test_manifesto
+++ b/test_manifesto
@@ -1,2 +1,0 @@
-logicalclocks/hopsworks/master
-logicalclocks/tensorflow-chef/master

--- a/test_manifesto
+++ b/test_manifesto
@@ -1,0 +1,2 @@
+logicalclocks/hopsworks-chef/HOPSWORKS-1229
+logicalclocks/conda-chef/HOPSWORKS-1229


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1229

This PR worked with the conda default channel, but not with our copy of the conda channel:

  conda:
    use_defaults: false
    channels:
      default_mirrors: http://snurran.sics.se/hops/conda/pkgs/main/linux-64,http://snurran.sics.se/hops/conda/pkgs/main/noarch

Maybe there is a more up-to-date copy of the conda repo somewhere, like bbc2?