### PR TITLE
test for HOPSWORKS-1691

### DIFF
--- a/templates/Vagrantfile-centos
+++ b/templates/Vagrantfile-centos
@@ -1,7 +1,14 @@
 Vagrant.configure("2") do |config|
 
+  common = <<-SCRIPT
+  sudo parted /dev/sda resizepart 2 100%
+  sudo pvresize /dev/sda2
+  sudo lvextend -l +100%FREE /dev/centos/root
+  sudo xfs_growfs /dev/centos/root
+  SCRIPT
+  
   config.ssh.insert_key = false
-  config.disksize.size = "50GB"
+  config.disksize.size = "100GB"
 
   config.vm.define "centos-name" do |hopsworks|
      hopsworks.vm.box = "bento/centos-7.7"
@@ -33,6 +40,8 @@ Vagrant.configure("2") do |config|
        v.customize ["modifyvm", :id, "--name", "centos-name"]
        v.customize ["modifyvm", :id, "--cpus", "8"]
      end
+
+     config.vm.provision :shell, :inline => common
 
      hopsworks.vm.provision :chef_solo do |chef|
          chef.version = "13.4.19"

--- a/templates/Vagrantfile-ubuntu
+++ b/templates/Vagrantfile-ubuntu
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
-  config.disksize.size = "50GB"
+  config.disksize.size = "100GB"
 
   config.vm.define "ubuntu-name.2" do |hopsworks2|
     hopsworks2.vm.box = "ubuntu/bionic64"

--- a/templates/cluster-centos
+++ b/templates/cluster-centos
@@ -33,6 +33,15 @@ attrs:
       to: sre@logicalclocks.com
       from: hopsworks@logicalclocks.com
       smtp_host: mail.hello.com
+  hadoop_spark:
+    url: "http://snurran.sics.se/hops/hadoop3/spark-2.4.3.2-bin-without-hadoop-with-hive-with-r.tgz"
+  flink:
+    url: "http://snurran.sics.se/hops/hadoop3/flink-1.9.2.1-bin-scala_2.11.tgz"
+  livy:
+    url: "http://snurran.sics.se/hops/hadoop3/apache-livy-0.6.1.2-bin.zip"
+  hive2:
+    url: "http://snurran.sics.se/hops/hadoop3/apache-hive-3.0.0.3-bin.tar.gz"
+  
 
 
 groups:

--- a/templates/cluster-ubuntu
+++ b/templates/cluster-ubuntu
@@ -44,6 +44,14 @@ attrs:
       to: sre@logicalclocks.com
       from: hopsworks@logicalclocks.com
       smtp_host: mail.hello.com
+  hadoop_spark:
+    url: "http://snurran.sics.se/hops/hadoop3/spark-2.4.3.2-bin-without-hadoop-with-hive-with-r.tgz"
+  flink:
+    url: "http://snurran.sics.se/hops/hadoop3/flink-1.9.2.1-bin-scala_2.11.tgz"
+  livy:
+    url: "http://snurran.sics.se/hops/hadoop3/apache-livy-0.6.1.2-bin.zip"
+  hive2:
+    url: "http://snurran.sics.se/hops/hadoop3/apache-hive-3.0.0.3-bin.tar.gz"
 
 
 groups:

--- a/test_manifesto
+++ b/test_manifesto
@@ -1,2 +1,11 @@
-logicalclocks/hopsworks/master
-logicalclocks/hopsworks-chef/master
+berthoug/hopsworks/docker
+berthoug/hopsworks-chef/docker
+berthoug/spark-chef/docker
+berthoug/flink-chef/docker
+berthoug/livy-chef/docker
+berthoug/epipe-chef/docker
+berthoug/tensorflow-chef/docker
+berthoug/hopslog-chef/docker
+berthoug/airflow-chef/docker
+berthoug/hive-chef/docker
+berthoug/hops-hadoop-chef/docker


### PR DESCRIPTION
test for https://logicalclocks.atlassian.net/browse/HOPSWORKS-1691
and all its subtasks:
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1694
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1695
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1693
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1692
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1277
https://logicalclocks.atlassian.net/browse/HOPSWORKS-1281

The corresponding pull requests are:
https://github.com/logicalclocks/airflow-chef/pull/41
https://github.com/logicalclocks/tensorflow-chef/pull/121
https://github.com/logicalclocks/flink-chef/pull/30
https://github.com/logicalclocks/epipe-chef/pull/37
https://github.com/logicalclocks/hopslog-chef/pull/35
https://github.com/logicalclocks/hops-hadoop-chef/pull/203
https://github.com/logicalclocks/spark-chef/pull/96
https://github.com/logicalclocks/hive-chef/pull/50
https://github.com/logicalclocks/livy-chef/pull/41
https://github.com/logicalclocks/hopsworks-chef/pull/415
https://github.com/logicalclocks/hive/pull/10
https://github.com/logicalclocks/incubator-livy/pull/9
https://github.com/logicalclocks/flink/pull/3
https://github.com/logicalclocks/spark/pull/17
https://github.com/logicalclocks/hopsworks/pull/520