### PR TITLE
[HOPSWORKS-1864] Revert HopsFS data dir location to be compatible wit…

### DIFF
--- a/test_manifesto
+++ b/test_manifesto
@@ -1,2 +1,1 @@
-logicalclocks/hopsworks/master
-logicalclocks/hopsworks-chef/master
+smkniazi/hops-hadoop-chef/HOPSWORKS-1864


### PR DESCRIPTION
I have removed cloud_data_dir and cloud_data_dir_permissions parameters as they were not used

and I have reverted the data_dir path to .../hdfs/dn . For cloud I changed it to ../hdfs/dn/disk but, it breaks the upgrade.