### PR TITLE
[HOPS-1588] truncate leader election tables on upgrade

### DIFF
--- a/test_manifesto
+++ b/test_manifesto
@@ -1,2 +1,1 @@
-logicalclocks/hopsworks/master
-logicalclocks/hopsworks-chef/master
+smkniazi/hops-hadoop-chef/HOPS-1588


### PR DESCRIPTION
https://hopshadoop.atlassian.net/jira/software/c/projects/HOPS/issues/HOPS-1588/?filter=allissues

The leader namenode recreate these missing rows when a cluster restart is detected. Currently we detect cluster restart using the leader election tables. If the tables are empty then it means all the namenode(s) were shut down and it is safe for the leader to recreate these missing rows. During upgrades we have some rows left in the leader election tables by the previous version of Hops. Simply truncating the leader election tables will fix this problem.